### PR TITLE
Remove hardcoded tests directory path pattern

### DIFF
--- a/show-snapshots.js
+++ b/show-snapshots.js
@@ -7,7 +7,7 @@ let fs = require('fs')
 let readFile = promisify(fs.readFile)
 
 module.exports = async function showSnapshots (print, cwd, filter) {
-  let snaps = await globby('**/test/**/*.snap', {
+  let snaps = await globby('**/*.snap', {
     cwd, ignore: ['node_modules']
   })
 


### PR DESCRIPTION
For example, tests (and snapshots) may be placed in `__tests__` directory or another (default patterns are https://jestjs.io/docs/en/configuration#testmatch-arraystring and https://jestjs.io/docs/en/configuration#testregex-string--arraystring)