### PR TITLE
Correct extensions replacement in repoter title

### DIFF
--- a/show-snapshots.js
+++ b/show-snapshots.js
@@ -24,16 +24,27 @@ module.exports = async function showSnapshots (print, cwd, filter) {
   }))
 
   snaps.sort().reverse().forEach(file => {
+    let testExt
+    let fileExt
     let test = file
-      .replace(/\.test\.js\.snap$/, '')
+      .replace(
+        /(\.(spec|test))?(\.([jt]sx?))\.snap$/,
+        (match, p1, p2, p3) => {
+          testExt = p1
+          fileExt = p3
+          return ''
+        }
+      )
       .replace('__snapshots__' + sep, '')
     results[file].split('exports[`')
       .filter(str => !str.startsWith('// '))
       .filter(str => !filter || str.includes(filter))
       .forEach(str => {
         if (str.trim().length === 0) return
-        let [name, body] = str.replace(/"\s*`;\s*$/, '').split(/`] = `\s*"?/)
-        let title = `${ test }.test.js ${ name }`
+        let [name, body] = str
+          .replace(/"\s*`;\s*$/, '')
+          .split(/`] = `\s*"?/)
+        let title = `${ test }${ testExt || '' }${ fileExt } ${ name }`
         if (test === 'create-reporter') {
           if (body[0] === '{') return
           title = title.replace(/ 2$/, '')


### PR DESCRIPTION
Snapshot file name may content not only `.test.js` before `.snap`.
By default it matches to `/(\.(spec|test))?(\.([jt]sx?))/`.
Also it may be indirectly overrided in project's Jest config, but this case is not covered in PR.